### PR TITLE
Better use of memory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.adroll.cantor</groupId>
   <artifactId>cantor</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
 
   <properties>
     <hadoop.version>2.6.0</hadoop.version>

--- a/src/main/java/com/adroll/cantor/HLLWritable.java
+++ b/src/main/java/com/adroll/cantor/HLLWritable.java
@@ -5,6 +5,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.TreeSet;
 
 import org.apache.hadoop.io.Writable;
@@ -32,7 +33,7 @@ public class HLLWritable implements Writable, Serializable {
       of the contained <code>HLLCounter</code> representation. */
   protected int s;
   /** The HLL structure of the contained <code>HLLCounter</code> representation. */
-  protected byte[] M;
+  protected HashMap<Integer, Byte> M;
   /** The contents of the MinHash structure of the contained 
       <code>HLLCounter</code> representation.*/
   protected long[] minhash;
@@ -66,11 +67,11 @@ public class HLLWritable implements Writable, Serializable {
                       structure
      @param s         the <code>int</code> number of elements in the 
                       MinHash structure
-     @param M         the <code>byte[]</code> HLL structure
+     @param M         the <code>HashMap</code> HLL structure
      @param minhash   the <code>long[]</code> elements in the MinHash 
                       structure
   */
-  public HLLWritable(byte p, int k, int s, byte[] M, long[] minhash){
+  public HLLWritable(byte p, int k, int s, HashMap<Integer, Byte> M, long[] minhash){
     this.p = p;
     this.k = k;
     this.s = s;
@@ -86,7 +87,7 @@ public class HLLWritable implements Writable, Serializable {
   */
   public void set(HLLCounter h) {
     p = h.getP();
-    M = h.getByteArray();
+    M = h.getByteHashMap();
     k = h.getK();
     if(h.isIntersectable()){
       s = h.getMinHash().size();
@@ -98,7 +99,7 @@ public class HLLWritable implements Writable, Serializable {
     }
     int i = 0;
     if(h.getMinHash() != null){
-      for(Long l : h.getMinHash()){
+      for(Long l : h.getMinHash().toArray(new Long[0])){
         minhash[i] = l;
         i++;
       }
@@ -148,7 +149,7 @@ public class HLLWritable implements Writable, Serializable {
 
     byte newP = (byte)Math.min(p, other.p);
     int newK = Math.min(k, other.k);
-    byte[] newM = HLLCounter.safeUnion(M, other.M);
+    HashMap<Integer, Byte> newM = HLLCounter.safeUnion(M, other.M, (int)Math.pow(2, p), (int)Math.pow(2, other.p));
     // newMinhash will hold at most newK elements, but possibly less
     long[] newMinhash = new long[newK];
     int i=0, j=0;
@@ -219,8 +220,8 @@ public class HLLWritable implements Writable, Serializable {
         out.writeByte(p);
         out.writeInt(k);
         out.writeInt(s);
-        for(byte b : M){
-          out.writeByte(b);
+        for (int i=0; i < (int)Math.pow(2, p); i++){
+          out.writeByte((byte)(M.containsKey(i) ? M.get(i) : 0));
         }
         for(int i=0; i < s; i++){
           out.writeLong(minhash[i]);
@@ -253,12 +254,16 @@ public class HLLWritable implements Writable, Serializable {
       if (p < 0) {
         p = (byte) -p;
         int m = (int)Math.pow(2, p);
-        M = new byte[m];
+        M = new HashMap<>();
       } else {
         int m = (int)Math.pow(2, p);
-        M = new byte[m];
+        byte b = 0;
+        M = new HashMap<>();
         for(int i = 0; i < m; i++) {
-          M[i] = in.readByte();
+          b = in.readByte();
+          if (b != 0) {
+            M.put(i, b);
+          }
         }
       }
       minhash = new long[s];
@@ -272,7 +277,7 @@ public class HLLWritable implements Writable, Serializable {
          */
         int idx = (int)(x >>> (64 - p));
         long w = x << p;
-        M[idx] =  (byte)Math.max(M[idx], Long.numberOfLeadingZeros(w) + 1);
+        M.put(idx, (byte)Math.max(M.containsKey(idx) ? M.get(idx) : 0, Long.numberOfLeadingZeros(w) + 1));
       }
     } catch(Exception e) {
       throw new IOException(e);
@@ -289,7 +294,7 @@ public class HLLWritable implements Writable, Serializable {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + Arrays.hashCode(M);
+    result = prime * result + M.hashCode();
     result = prime * result + k;
     result = prime * result + Arrays.hashCode(minhash);
     result = prime * result + p;
@@ -323,7 +328,7 @@ public class HLLWritable implements Writable, Serializable {
       return false;
     }
     HLLWritable other = (HLLWritable) obj;
-    if (!Arrays.equals(M, other.M)) {
+    if (!M.equals(other.M)) {
       return false;
     }
     if (k != other.k) {

--- a/src/test/java/com/adroll/cantor/TestHLLCounter.java
+++ b/src/test/java/com/adroll/cantor/TestHLLCounter.java
@@ -135,7 +135,7 @@ public class TestHLLCounter {
     HLLCounter big = new HLLCounter((byte)12);
     fillHLLCounter(big, r, 100000);
     big.fold((byte)8);
-    
+
     assertEquals(big.size(), small.size());
 
     r = new Random(23456L);

--- a/src/test/java/com/adroll/cantor/TestHLLWritable.java
+++ b/src/test/java/com/adroll/cantor/TestHLLWritable.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.util.HashMap;
 
 import org.junit.Test;
 
@@ -36,7 +37,7 @@ public class TestHLLWritable {
     assertEquals(3L, d.size());
     assertEquals(HLLCounter.DEFAULT_K, d.getK());
     assertTrue(d.isIntersectable());
-    assertArrayEquals(hll.getByteArray(), d.getByteArray());
+    assertEquals(hll.getByteHashMap(), d.getByteHashMap());
     assertArrayEquals(hll.getMinHash().toArray(), d.getMinHash().toArray());
   }
   
@@ -61,7 +62,7 @@ public class TestHLLWritable {
     assertEquals(0, d.getK());
     assertFalse(d.isIntersectable());
     assertNull(d.getMinHash());
-    assertArrayEquals(hll.getByteArray(), d.getByteArray());
+    assertEquals(hll.getByteHashMap(), d.getByteHashMap());
   }
   
   @Test
@@ -85,7 +86,7 @@ public class TestHLLWritable {
     assertEquals(5L, d.size());
     assertEquals(3, d.getK());
     assertTrue(d.isIntersectable());
-    assertArrayEquals(hll.getByteArray(), d.getByteArray());
+    assertEquals(hll.getByteHashMap(), d.getByteHashMap());
     assertArrayEquals(hll.getMinHash().toArray(), d.getMinHash().toArray());
   }
   
@@ -117,7 +118,7 @@ public class TestHLLWritable {
     assertEquals(5L, d.size());
     assertEquals(256, d.getK());
     assertTrue(d.isIntersectable());
-    assertArrayEquals(hll.getByteArray(), d.getByteArray());
+    assertEquals(hll.getByteHashMap(), d.getByteHashMap());
     assertArrayEquals(hll.getMinHash().toArray(), d.getMinHash().toArray());
   }
     
@@ -221,11 +222,11 @@ public class TestHLLWritable {
   @Test
   public void test_combine_empty() throws Exception {
     HLLWritable empty =  
-      new HLLWritable((byte)15, Integer.MAX_VALUE, 0, new byte[(int)Math.pow(2, (byte)15)], new long[0]);
+      new HLLWritable((byte)15, Integer.MAX_VALUE, 0, new HashMap<Integer, Byte>(), new long[0]);
     assertEquals(0, empty.get().getMinHash().size());
     
     HLLWritable empty2 =
-      new HLLWritable((byte)15, 8192, 0, new byte[(int)Math.pow(2, (byte)15)], new long[0]);
+      new HLLWritable((byte)15, 8192, 0, new HashMap<Integer, Byte>(), new long[0]);
     assertEquals(0, empty2.get().getMinHash().size());
     
     empty = empty.combine(empty2);


### PR DESCRIPTION
In our use case (lots of high precision HLLs with very few values in them) it is far more memory efficient to use a HashMap to store the HLL data than a byte array. A byte array reserved memory whether or it gets used whereas a HashMap can use memory for only the keys/indices it needs