### PR TITLE
Lighter HLLs

### DIFF
--- a/src/main/java/com/adroll/cantor/HLLCounter.java
+++ b/src/main/java/com/adroll/cantor/HLLCounter.java
@@ -245,8 +245,8 @@ public class HLLCounter implements Serializable {
       md.update(v.getBytes());
       byte[] b = md.digest();
       md.reset();
-      //We just want 64 bits
-      b = new byte[] { b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7] };
+      //We just want 48 bits
+      b = new byte[] { 0, 0, b[2], b[3], b[4], b[5], b[6], b[7] };
       x = makelong(b);
       if (updateCache) {
         md5Cache.put(v, x);
@@ -727,7 +727,7 @@ public class HLLCounter implements Serializable {
 
      @return  the <code>long</code> of this hash
   */
-  private static long makelong(byte[] x) {
+  public static long makelong(byte[] x) {
     long y = 0L;
     for(int i = 0; i < x.length; i++) {
       y += ((long)x[i] & 0xffL) << (8*(i + 8 - x.length));

--- a/src/main/java/com/adroll/cantor/HLLCounter.java
+++ b/src/main/java/com/adroll/cantor/HLLCounter.java
@@ -730,7 +730,7 @@ public class HLLCounter implements Serializable {
   private static long makelong(byte[] x) {
     long y = 0L;
     for(int i = 0; i < x.length; i++) {
-      y += ((long)x[i]) << (8*i);
+      y += ((long)x[i] & 0xffL) << (8*(i + 8 - x.length));
     }
     return y;
   }

--- a/src/main/java/com/adroll/cantor/HLLCounter.java
+++ b/src/main/java/com/adroll/cantor/HLLCounter.java
@@ -479,6 +479,8 @@ public class HLLCounter implements Serializable {
     //intersection using the MinHash algorithm.
     if (hs.size() == 0) {
       return 0;
+    } else if (hs.size() == 1 && hs.get(0).isIntersectable()) {
+      return (long)(totalSize(hs));
     }
     for (HLLCounter hll : hs) {
       if ((hll.getMinHash() == null && hll.size() == 0) || hll.getMinHash().size() == 0) {

--- a/src/test/java/com/adroll/cantor/TestHLLCounter.java
+++ b/src/test/java/com/adroll/cantor/TestHLLCounter.java
@@ -101,28 +101,28 @@ public class TestHLLCounter {
     Random r = new Random(4618201L);
     HLLCounter h = new HLLCounter((byte)8);
     fillHLLCounter(h, r, 25851093);
-    assertTrue(h.size() == 22787413L);
+    assertTrue(h.size() == 23296261L);
 
     r = new Random(8315542L); 
     h = new HLLCounter((byte)9); 
-    fillHLLCounter(h, r, 4954434); 
-    assertTrue(h.size() == 5013953L);
+    fillHLLCounter(h, r, 4954434);
+    assertTrue(h.size() == 4918828L);
 
     //default precision of HLLCounter.DEFAULT_P = 18
     h = new HLLCounter();
     r = new Random(73919566L); 
-    fillHLLCounter(h, r, 17078033); 
-    assertTrue(h.size() == 17034653L);
+    fillHLLCounter(h, r, 17078033);
+    assertTrue(h.size() == 17041645L);
 
     h.clear();
     r = new Random(57189216L); 
-    fillHLLCounter(h, r, 18592874); 
-    assertTrue(h.size() == 18526241L);
+    fillHLLCounter(h, r, 18592874);
+    assertTrue(h.size() == 18568108L);
 
     h.clear();
     r = new Random(10821894L);
-    fillHLLCounter(h, r, 3777716); 
-    assertTrue(h.size() == 3760602L);
+    fillHLLCounter(h, r, 3777716);
+    assertTrue(h.size() == 3764579L);
 	}
 
   @Test
@@ -180,17 +180,17 @@ public class TestHLLCounter {
       h3.put(String.valueOf(i));
     }
 
-    assertEquals(4853, HLLCounter.intersect(h0, h1)); //about 5000
-    assertEquals(1922, HLLCounter.intersect(h0, h2)); //about 2000
-    assertEquals(937, HLLCounter.intersect(h0, h3)); //about 1000
-    assertEquals(2963, HLLCounter.intersect(h1, h2)); //about 3000
-    assertEquals(958, HLLCounter.intersect(h1, h3)); //about 1000
+    assertEquals(4827, HLLCounter.intersect(h0, h1)); //about 5000
+    assertEquals(1944, HLLCounter.intersect(h0, h2)); //about 2000
+    assertEquals(928, HLLCounter.intersect(h0, h3)); //about 1000
+    assertEquals(2984, HLLCounter.intersect(h1, h2)); //about 3000
+    assertEquals(968, HLLCounter.intersect(h1, h3)); //about 1000
     assertEquals(986, HLLCounter.intersect(h2, h3)); //about 1000
-    assertEquals(1862, HLLCounter.intersect(h0, h1, h2)); //about 2000
-    assertEquals(762, HLLCounter.intersect(h0, h1, h3)); //about 1000
-    assertEquals(934, HLLCounter.intersect(h0, h2, h3)); //about 1000
-    assertEquals(958, HLLCounter.intersect(h1, h2, h3)); //about 1000
-    assertEquals(762, HLLCounter.intersect(h0, h1, h2, h3)); //about 1000
+    assertEquals(1804, HLLCounter.intersect(h0, h1, h2)); //about 2000
+    assertEquals(748, HLLCounter.intersect(h0, h1, h3)); //about 1000
+    assertEquals(956, HLLCounter.intersect(h0, h2, h3)); //about 1000
+    assertEquals(968, HLLCounter.intersect(h1, h2, h3)); //about 1000
+    assertEquals(748, HLLCounter.intersect(h0, h1, h2, h3)); //about 1000
     assertEquals(0, HLLCounter.intersect());
     assertEquals(0, HLLCounter.intersect(new HLLCounter(), h0));    
     

--- a/src/test/java/com/adroll/cantor/TestHLLWritable.java
+++ b/src/test/java/com/adroll/cantor/TestHLLWritable.java
@@ -6,6 +6,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.junit.Test;
 
@@ -148,7 +150,7 @@ public class TestHLLWritable {
     HLLWritable deser1 = new HLLWritable();
     deser1.readFields(in);
     
-    assertEquals(998974, HLLCounter.intersect(deser0.get(), deser1.get()));
+    assertEquals(996309, HLLCounter.intersect(deser0.get(), deser1.get()));
   }
   
   @Test


### PR DESCRIPTION
- [x] Use 6 bytes instead of 8 for hashed values
- [x] Bugfix: makelong did not work as expected
- [x] Optimization: Intersecting a single HLL returns the size of that HLL